### PR TITLE
New options: custom message, and put enrolled users in a group #14

### DIFF
--- a/edit.php
+++ b/edit.php
@@ -71,10 +71,12 @@ if ($mform->is_cancelled()) {
 
         $instance->status         = $data->status;
         $instance->name           = $data->name;
+        $instance->customtext1    = $data->customtext1;
         $instance->cost           = unformat_float($data->cost);
         $instance->currency       = $data->currency;
         $instance->roleid         = $data->roleid;
         $instance->customint3     = $data->customint3;
+        $instance->customint4     = $data->customint4;
         $instance->enrolperiod    = $data->enrolperiod;
         $instance->enrolstartdate = $data->enrolstartdate;
         $instance->enrolenddate   = $data->enrolenddate;

--- a/edit_form.php
+++ b/edit_form.php
@@ -46,8 +46,13 @@ class enrol_stripepayment_edit_form extends moodleform {
 
         $mform->addElement('header', 'header', get_string('pluginname', 'enrol_stripepayment'));
 
-        $mform->addElement('text', 'name', get_string('custominstancename', 'enrol'));
+        $mform->addElement('text', 'name', get_string('custominstancename', 'enrol'), array('size' => 60));
         $mform->setType('name', PARAM_TEXT);
+
+        $mform->addElement('textarea', 'customtext1', get_string('customwelcomemessage', 'enrol_stripepayment'),
+                array('rows' => 3, 'cols' => 80));
+        $mform->setType('customtext1', PARAM_TEXT);
+        $mform->addHelpButton('customtext1', 'customwelcomemessage', 'enrol_stripepayment');
 
         $options = array(ENROL_INSTANCE_ENABLED  => get_string('yes'),
                          ENROL_INSTANCE_DISABLED => get_string('no'));
@@ -70,7 +75,20 @@ class enrol_stripepayment_edit_form extends moodleform {
         $mform->addElement('select', 'roleid', get_string('assignrole', 'enrol_stripepayment'), $roles);
         $mform->setDefault('roleid', $plugin->get_config('roleid'));
 
-        $mform->addElement('text', 'customint3', get_string('maxenrolled', 'enrol_stripepayment'));
+        // Group selector - only if there are groups in this course.
+        $groupdata = groups_get_course_data($instance->courseid);
+        if ($groupdata->groups) {
+            $options = array();
+            foreach ($groupdata->groups as $group) {
+                $options[$group->id] = format_string($group->name);
+            }
+        }
+        core_collator::asort($options);
+        $options = array(0 => get_string('none')) + $options;
+        $mform->addElement('select', 'customint4', get_string('addtogroup', 'enrol_stripepayment'), $options);
+        $mform->addHelpButton('customint4', 'addtogroup', 'enrol_stripepayment');
+
+        $mform->addElement('text', 'customint3', get_string('maxenrolled', 'enrol_stripepayment'), array('size' => 3));
         $mform->setDefault('maxenrolled', 'customint3');
         $mform->addHelpButton('customint3', 'maxenrolled', 'enrol_stripepayment');
         $mform->setType('customint3', PARAM_INT);

--- a/enrol.html
+++ b/enrol.html
@@ -1,6 +1,6 @@
-<div align="center">
-<p><?php print_string("paymentrequired") ?></p>
-<p><b><?php echo $instancename; ?></b></p>
+<div class="mdl-align">
+<h3><?php echo $instancename; ?></h3>
+<p><?php echo $message; ?></p>
 <p><b><?php echo get_string("cost").": {$instance->currency} {$localisedcost}"; ?></b></p>
 
 <form action="<?php echo "$CFG->wwwroot/enrol/stripepayment/charge.php"?>" method="post">

--- a/lang/en/enrol_stripepayment.php
+++ b/lang/en/enrol_stripepayment.php
@@ -22,7 +22,10 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+$string['addtogroup'] = 'Add to group';
+$string['addtogroup_help'] = 'If you select a group here, then when a user completes the payment process and is enrolled in this course, they will be added to this group.';
 $string['assignrole'] = 'Assign role';
+$string['assignrole_help'] = 'If you select a role here, then when a user completes the payment process and is enrolled in this course, they will be assigned this role.';
 $string['secretkey'] = 'Stripe Secret Key';
 $string['publishablekey'] = 'Stripe Publishable Key';
 $string['secretkey_desc'] = 'The API Secret Key of Stripe account';
@@ -31,6 +34,8 @@ $string['cost'] = 'Enrol cost';
 $string['costerror'] = 'The enrolment cost is not numeric';
 $string['costorkey'] = 'Please choose one of the following methods of enrolment.';
 $string['currency'] = 'Currency';
+$string['customwelcomemessage'] = 'Custom welcome message';
+$string['customwelcomemessage_help'] = 'If you enter some text here, it will be shown instead of the standard text "This course requires a payment for entry." on the Enrolment options page that students see when they attempt to access a course they are not enrolled in. If you leave this blank, the standard text will be used.';
 $string['defaultrole'] = 'Default role assignment';
 $string['defaultrole_desc'] = 'Select role which should be assigned to users during Stripe enrolments';
 $string['enrolenddate'] = 'End date';

--- a/lib.php
+++ b/lib.php
@@ -257,6 +257,11 @@ class enrol_stripepayment_plugin extends enrol_plugin {
                 $useraddress     = $USER->address;
                 $usercity        = $USER->city;
                 $instancename    = $this->get_instance_name($instance);
+                if (!empty($instance->customtext1)) {
+                    $message = format_string($instance->customtext1);
+                } else {
+                    $message = get_string("paymentrequired");
+                }
 
                 include($CFG->dirroot.'/enrol/stripepayment/enrol.html');
             }


### PR DESCRIPTION
I think this is the necessary changes to fix Issue #14. I am afraid that, as part of this change, I made some unrelated changes to the HTML. It would probably have been better to do these as a separate change, and if you prefer I can separate out the changes necessary to implement the new feature, and we can discuss the other HTML changes separately. 

Here are the details of the HTML changes I made: On the Enrol
options page when a user tries to enter a course.
 * I swapped the order of the instancename, and the message. The instancename looks like a heading, that seemed more natural. Note that Moodle's standard self-enrolment plugin now puts the instance name before the message.
 * I change the instance name to acutally be a heading. This is better for accessibility. I also think it looks better.
 * I changed the hard-coded align="center" to align="center".

On the edit form:
* I changed the size of some of the input boxes (Custom instance name and Max Enrolled users). I hope the new sizes are better.

Thank you for considering this. Tim.