### PR TITLE
secret key leak on js is fixed

### DIFF
--- a/enrol.php
+++ b/enrol.php
@@ -32,6 +32,14 @@
 defined('MOODLE_INTERNAL') || die();
 global $CFG;
 ?>
+
+<?php
+              $_SESSION['amount']=$cost;
+              $_SESSION['description']=$coursefullname;
+              $_SESSION['courseid']=$course->id;
+              $_SESSION['currency']=$instance->currency;
+?>
+
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js">
 </script>
 <script>
@@ -184,11 +192,6 @@ if ($costvalue == 000) {  ?>
           url: "<?php echo $CFG->wwwroot; ?>/enrol/stripepayment/paymentintendsca.php",
           method: 'POST',
           data: {
-              'secretkey' : "<?php echo $this->get_config('secretkey'); ?>",
-              'amount' : "<?php echo str_replace(".", "", $cost); ?>",
-              'currency' : "<?php echo strtolower($instance->currency); ?>",
-              'description' : "<?php echo 'Enrolment charge for '.$coursefullname; ?>",
-              'courseid' : "<?php echo $course->id; ?>",
               'receiptemail' : emailId,
           },
 

--- a/paymentintendsca.php
+++ b/paymentintendsca.php
@@ -31,12 +31,15 @@ require_once('../../config.php');
 require('Stripe/init.php');
 global $DB, $USER, $CFG;
 
-$secretkey = required_param('secretkey', PARAM_RAW);
-$courseid = required_param('courseid', PARAM_RAW);
-$amount = required_param('amount', PARAM_RAW);
-$currency = required_param('currency', PARAM_RAW);
-$description = required_param('description', PARAM_RAW);
-$receiptemail = required_param('receiptemail', PARAM_RAW);
+$plugin = enrol_get_plugin('stripepayment');
+
+
+$secretkey = $plugin->get_config('secretkey');
+$courseid = $_SESSION('courseid');
+$amount = $_SESSION('amount');
+$currency = $_SESSION('currency');
+$description = $_SESSION('description');
+$receiptemail = $_SESSION('receiptemail');
 
 if(empty($secretkey) || empty($courseid) || empty($amount) || empty($currency) || empty($description) || empty($receiptemail)) {
 	redirect($CFG->wwwroot.'/course/view.php?id='.$courseid);


### PR DESCRIPTION
### This project contained some serious vulnerabilities,

1. Sensitive data exposure
**# file - enrol.php**
_from line no. 187_
```
'secretkey' : "<?php echo $this->get_config('secretkey'); ?>",
'amount' : "<?php echo str_replace(".", "", $cost); ?>",
'currency' : "<?php echo strtolower($instance->currency); ?>",
'description' : "<?php echo 'Enrolment charge for '.$coursefullname; ?>",
'courseid' : "<?php echo $course->id; ?>",
'receiptemail' : emailId,
```

from the above code, you can see **the plugin leaking the stripe secret key.** This key should be stored on the server and never exposed to the public. 